### PR TITLE
qsearch skip quiet

### DIFF
--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -626,6 +626,11 @@ i32 Engine::qsearch(Data& data, i32 alpha, i32 beta)
         // Unmakes move
         data.unmake(move);
 
+        // Aborts search
+        if (!this->running.test()) {
+            return eval::score::DRAW;
+        }
+
         // Skips quiet moves if we've found non-mate score
         if (is_in_check && score > -eval::score::MATE_FOUND) {
             picker.skip_quiets();

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -626,6 +626,11 @@ i32 Engine::qsearch(Data& data, i32 alpha, i32 beta)
         // Unmakes move
         data.unmake(move);
 
+        // Skips quiet moves if we've found non-mate score
+        if (is_in_check && score > -eval::score::MATE_FOUND) {
+            picker.skip_quiets();
+        }
+
         // Updates best
         if (score > best) {
             best = score;


### PR DESCRIPTION
Elo difference: 30.6 +/- 14.7, LOS: 100.0 %, DrawRatio: 40.8 %
SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted