### PR TITLE
futility pruning

### DIFF
--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -379,8 +379,9 @@ i32 Engine::pvsearch(Data& data, i32 alpha, i32 beta, i32 depth)
                 !is_in_check &&
                 is_quiet &&
                 lmr_depth <= tune::fp::DEPTH &&
-                eval + lmr_depth * tune::fp::COEF + tune::fp::BIAS <= alpha) {
+                eval_static + lmr_depth * tune::fp::COEF + tune::fp::BIAS <= alpha) {
                 picker.skip_quiets();
+                continue;
             }
         }
 

--- a/src/engine/tune.h
+++ b/src/engine/tune.h
@@ -33,7 +33,7 @@ namespace lmp
 
 namespace fp
 {
-    constexpr i32 COEF = 50;
+    constexpr i32 COEF = 100;
     constexpr i32 BIAS = 50;
     constexpr i32 DEPTH = 10;
 };


### PR DESCRIPTION
Elo difference: 24.8 +/- 15.5, LOS: 99.9 %, DrawRatio: 40.7 %
SPRT: llr 2.2 (100.2%), lbound -2.2, ubound 2.2 - H1 was accepted